### PR TITLE
Prepare a docker image for build mdbook-scientific

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,29 @@
+name: github pages
+
+on:
+  push:
+    branches:
+      - master-test-build # todo, change to master later
+
+jobs:
+  deploy:
+    runs-on: ubuntu-18.04
+    # https://www.petefreitag.com/item/903.cfm
+    container:
+      image: liufuyang/mdbook-scientific:0.3.7
+    steps:
+      - uses: actions/checkout@v2
+
+      # - name: Setup mdBook
+      #   uses: peaceiris/actions-mdbook@v1
+      #   with:
+      #     mdbook-version: '0.4.6'
+      #     mdbook-version: 'latest'
+      - run: mdbook build
+      - run: ls ./book
+
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./book

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 mdbook-scientific/target/*
 book/*
+*.aux
+fragments
+src/assets

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 FROM ekidd/rust-musl-builder:1.50.0 as cargo-build
 
 RUN cargo install mdbook --version 0.3.7
-COPY --chown=rust:rust . /book
+COPY --chown=rust:rust ./mdbook-scientific /book/mdbook-scientific
 WORKDIR /book/mdbook-scientific
 RUN cargo install --path .
 
@@ -13,7 +13,7 @@ RUN cargo install --path .
 # Final Stage
 # ------------------------------------------------------------------------------
 
-FROM alpine/git:v2.30.1
+FROM ubuntu:18.04
 
 # Install glibc which mdbook needs, if we don't use musl builder;
 # Now we use something mentioned here, "ekidd/rust-musl-builder" seems the simplest:
@@ -23,7 +23,35 @@ FROM alpine/git:v2.30.1
 COPY --from=cargo-build /home/rust/.cargo/bin/mdbook /bin/mdbook
 COPY --from=cargo-build /home/rust/.cargo/bin/mdbook-scientific /bin/mdbook-scientific
 
+# Install latex, tikz and so on via texlive
+# https://linuxconfig.org/how-to-install-latex-on-ubuntu-18-04-bionic-beaver-linux
+# https://launchpad.net/ubuntu/bionic/+package/texlive-pictures
+RUN apt update
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt install -y git gnuplot texlive texlive-latex-extra 
+RUN apt install -y texlive-science texlive-pictures
+# RUN apt install -y texlive-full
+
+# Install bib2xhtml at /github/bib2xhtml/
+WORKDIR /github
+RUN git clone https://github.com/dspinellis/bib2xhtml.git
+WORKDIR /github/bib2xhtml/
+RUN ./gen-bst.pl
+
+# Install Rust - just trying build the mdbook stuff in Ubuntu to see whether it helps, but nothing changes, commented here for future convenience
+# RUN apt install -y curl
+# RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+# ENV PATH="${PATH}:/root/.cargo/bin"
+# RUN apt install -y gcc
+# RUN cargo install mdbook --version 0.3.7
+# COPY --chown=rust:rust ./mdbook-scientific /book/mdbook-scientific
+# WORKDIR /book/mdbook-scientific
+# RUN cargo install --path .
+# RUN rm /bin/mdbook*
+
+
 WORKDIR /github/workspace/
 ENTRYPOINT ["mdbook"]
 
-# docker run --rm -it -v $(pwd):/github/workspace liufuyang/mdbook-scientific:0.3.7 build
+# docker run --rm -v $(pwd):/github/workspace liufuyang/mdbook-scientific:0.3.7 build
+# docker run --rm -v $(pwd):/github/workspace --name mdbook -p 3000:3000 liufuyang/mdbook-scientific:0.3.7 serve -n 0.0.0.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,4 +26,4 @@ COPY --from=cargo-build /home/rust/.cargo/bin/mdbook-scientific /bin/mdbook-scie
 WORKDIR /github/workspace/
 ENTRYPOINT ["mdbook"]
 
-# docker run --rm -it -v $(pwd):/github/workspace liufuyang/mdbook-scientific:0.4.7 build
+# docker run --rm -it -v $(pwd):/github/workspace liufuyang/mdbook-scientific:0.3.7 build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+# ------------------------------------------------------------------------------
+# Cargo Build Stage
+# ------------------------------------------------------------------------------
+
+FROM ekidd/rust-musl-builder:1.50.0 as cargo-build
+
+RUN cargo install mdbook --version 0.3.7
+COPY --chown=rust:rust . /book
+WORKDIR /book/mdbook-scientific
+RUN cargo install --path .
+
+# ------------------------------------------------------------------------------
+# Final Stage
+# ------------------------------------------------------------------------------
+
+FROM alpine/git:v2.30.1
+
+# Install glibc which mdbook needs, if we don't use musl builder;
+# Now we use something mentioned here, "ekidd/rust-musl-builder" seems the simplest:
+# https://stackoverflow.com/questions/49098753/unable-to-run-a-docker-image-with-a-rust-executable
+# https://dev.to/sergeyzenchenko/actix-web-in-docker-how-to-build-small-and-secure-images-2mjd
+
+COPY --from=cargo-build /home/rust/.cargo/bin/mdbook /bin/mdbook
+COPY --from=cargo-build /home/rust/.cargo/bin/mdbook-scientific /bin/mdbook-scientific
+
+WORKDIR /github/workspace/
+ENTRYPOINT ["mdbook"]
+
+# docker run --rm -it -v $(pwd):/github/workspace liufuyang/mdbook-scientific:0.4.7 build

--- a/book.toml
+++ b/book.toml
@@ -10,7 +10,7 @@ title = "Rust Machine Learning Book"
 renderer = ["html"]
 
 bibliography = "literature.bib"
-bib2xhtml = ""
+bib2xhtml = "/github/bib2xhtml/"
 
 # assets = "src/"
 assets = "mdbook-scientific"

--- a/build.docker.sh
+++ b/build.docker.sh
@@ -1,0 +1,3 @@
+docker build -t liufuyang/mdbook-scientific:0.4.7 .
+# docker login
+# docker push liufuyang/mdbook-scientific:0.4.7

--- a/build.docker.sh
+++ b/build.docker.sh
@@ -1,3 +1,3 @@
-docker build -t liufuyang/mdbook-scientific:0.4.7 .
+docker build -t liufuyang/mdbook-scientific:0.3.7 .
 # docker login
-# docker push liufuyang/mdbook-scientific:0.4.7
+# docker push liufuyang/mdbook-scientific:0.3.7

--- a/src/2_intro.md
+++ b/src/2_intro.md
@@ -16,8 +16,8 @@ Conversely, we don't assume an in-depth knowledge of machine learning (i.e. math
 
 Each chapter's code sample will be available in its entirety in the `code/` directory, and can be run independently of the book. For example, to run the entirety of the code example for the KMeans algorithm, the steps would look like the following:
 ```bash
-user@computer:~/rust-ml/book$ cd code/
-user@computer:~/rust-ml/book/code$ cargo run --release --example kmeans
+user@computer:~/rust-ml/book cd code/
+user@computer:~/rust-ml/book/code cargo run --release --example kmeans
 ```
 
 ## An additional note

--- a/src/chapter_1.md
+++ b/src/chapter_1.md
@@ -2,9 +2,15 @@
 
 A simple demonstration of latex and gnuplot integration into `mdbook`.
 
-$$latex, hyperplane, Influence of an outlier to the separating hyperplane, note that a single support vector changes the border completely$$
+The current mdbook-science
 
-This is a test to $ref:fig:hyperplane$ blub.
+These lines related to hyperplane is not working
+
+Other stuff works:
+
+$$equation, energy
+E = m C^2
+$$
 
 $$equation, svm
 \begin{aligned}
@@ -22,34 +28,4 @@ set ztics  -100,40,100
 splot x**2-y**2 with lines title "$x^2 - y^2$", x**2-y**2 with labels boxed notitle
 $$
 
-
 We should reference this $ref:bib:legendreintegral$ and inline math $\sum_i \frac{a}{b}$ should also work and this $ref:equ:svm$.
-
-```
-# Chapter 1
-
-A simple demonstration of latex and gnuplot integration into `mdbook`.
-
-$$latex, hyperplane, Influence of an outlier to the seperating hyperplane, note that a single support vector changes the border completely$$
-
-This is a test to $ref:fig:hyperplane$ blub.
-
-$$equation, svm
-\begin{aligned}
-0 \leq \lambda_i^{\ast} \leq c &\implies y_i(\mathbf{a}^{\ast^T}\mathbf{x}_i+b^{\ast}) = 1 \quad \text{e.g. support vector} \\
-\lambda_i^{\ast} = c &\implies y_i(\mathbf{a}^{\ast^T}\mathbf{x}_i+b^{\ast}) \leq 1 \quad \text{e.g. outlier vector} \\
-\lambda_i^{\ast} = 0 &\implies y_i(\mathbf{a}^{\ast^T}\mathbf{x}_i+b^{\ast}) \geq 1
-\end{aligned}
-$$
-
-$$gnuplot, contour, Contour test plot
-set title "contours on both base and surface"
-set contour both
-set hidden3d
-set ztics  -100,40,100
-splot x**2-y**2 with lines title "$x^2 - y^2$", x**2-y**2 with labels boxed notitle
-$$
-
-
-We should reference this $ref:bib:legendreintegral$ and inline math $\sum_i \frac{a}{b}$ should also work and this $ref:equ:svm$.
-```


### PR DESCRIPTION
related to https://github.com/rust-ml/book/issues/5#issuecomment-801730275

Basic idea is to have a docker image that contains working programs such as `mdbook` and `mdbook-scientific`. 

**WIP**, need to install `bib2xhtml` in the build image (alpine linux)

For now at least `mdbook` and `mdbook-scientific` are packed into the docker image.
``` 
docker run --rm -it -v $(pwd):/github/workspace liufuyang/mdbook-scientific:0.3.7 build

2021-03-23 08:29:50 [INFO] (mdbook::book): Book building has started
thread 'main' panicked at 'Could not spawn bib2xhtml: Os { code: 2, kind: NotFound, message: "No such file or directory" }', src/fragments.rs:250:10
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
2021-03-23 08:29:50 [ERROR] (mdbook::utils): Error: The preprocessor exited unsuccessfully
```

We can switch the docker image to your organization's image base, and perhaps move docker file to another repo, if that is what you think a better thing to do. Now I would like to illustrate the CI idea via this PR and perhaps you can comment on it.

Also, in order for me to test this, do you mind create a `master-test-build` branch from current master? Thank you :)